### PR TITLE
check scope params

### DIFF
--- a/src/twitch.ts
+++ b/src/twitch.ts
@@ -19,10 +19,10 @@ export const authorize = ({
 }: AuthorizeProps) => {
   const params = new URLSearchParams({
     response_type: "code",
-    scope: scopes.join(" "),
     client_id: clientId,
     redirect_uri: callbackURL,
     ...(csrfToken ? { state: csrfToken } : {}),
+    ...(scopes.length > 0 ? { scope: scopes.join(" ") } : {}),
   });
   return `${requestAuthorizeURL}?${params.toString()}`;
 };


### PR DESCRIPTION
When `includeEmail` is `false`, the generated authorization URL has been improved.
The old URL was `xxx&scope=&redirect=xxx`, and the new URL is `xxx&redirect=xxx`.

